### PR TITLE
Re-adding rate-limiting

### DIFF
--- a/api/entities/challenge.go
+++ b/api/entities/challenge.go
@@ -2,12 +2,12 @@ package entities
 
 import (
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
 )
 
 // how long a signature will ultimately be valid for
@@ -41,7 +41,7 @@ func NewChallenge(address string, message string, expires time.Time) Challenge {
 func GenerateChallenge(address string) Challenge {
 	now := time.Now()
 	ttl := CHALLENGE_TTL
-	nonce := fmt.Sprintf("%10d", rand.Intn(10000000000))
+	nonce := uuid.New().String()
 	return Challenge{
 		address: address,
 		message: fmt.Sprintf(CHALLENGE_MESSAGE, address, now.Format(time.RFC3339), nonce),

--- a/api/gateways/gateways.go
+++ b/api/gateways/gateways.go
@@ -2,6 +2,7 @@ package gateways
 
 import (
 	"context"
+	"time"
 
 	"github.com/daochanio/backend/api/entities"
 )
@@ -30,7 +31,7 @@ type CacheGateway interface {
 	GetChallengeByAddress(ctx context.Context, address string) (entities.Challenge, error)
 	SaveChallenge(ctx context.Context, challenge entities.Challenge) error
 
-	VerifyRateLimit(ctx context.Context, ipAddress string) error
+	VerifyRateLimit(ctx context.Context, key string, rate int, period time.Duration) error
 }
 
 type BlockchainGateway interface {

--- a/api/gateways/redis/rate_limit.go
+++ b/api/gateways/redis/rate_limit.go
@@ -4,24 +4,33 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-redis/redis_rate/v10"
 )
 
-func (r *redisGateway) VerifyRateLimit(ctx context.Context, ipAddress string) error {
-	res, err := r.limiter.Allow(ctx, ipAddress, redis_rate.PerSecond(10))
+// this rate limit implementation is based on the leaky bucket algorithm
+// it is more memory efficient than the fixed/sliding window algorithm
+// but it is not as precise and may surprise people when first configuring the rate/period
+// as it can allow up to 2x the rate limit in a single period
+func (r *redisGateway) VerifyRateLimit(ctx context.Context, key string, rate int, period time.Duration) error {
+	res, err := r.limiter.Allow(ctx, key, redis_rate.Limit{
+		Rate:   rate,
+		Period: period,
+		Burst:  rate,
+	})
 
 	if err != nil {
-		return fmt.Errorf("rate limit error %w", err)
+		return fmt.Errorf("rate limit error %w for key %v", err, key)
 	}
 
-	if res.Remaining == 0 {
-		return fmt.Errorf("rate limit exceeded %v", res.Limit)
+	if res.Allowed == 0 {
+		return fmt.Errorf("rate limit %v exceeded for %v", res.Limit, key)
 	}
 
 	return nil
 }
 
 func getFullKey(namespace string, keys ...string) string {
-	return fmt.Sprintf("%v-%v", namespace, strings.Join(keys, "-"))
+	return fmt.Sprintf("%v:%v", namespace, strings.Join(keys, ":"))
 }

--- a/api/http/rate_limit.go
+++ b/api/http/rate_limit.go
@@ -1,24 +1,33 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/daochanio/backend/api/usecases"
 )
 
-func (h *httpServer) rateLimit(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+func (h *httpServer) rateLimit(namespace string, rate int, period time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
 
-		err := h.verifyRateLimitUseCase.Execute(ctx, &usecases.VerifyRateLimitInput{
-			IpAddress: r.RemoteAddr,
+			fmt.Println("rateLimit", namespace, rate, period)
+
+			err := h.verifyRateLimitUseCase.Execute(ctx, &usecases.VerifyRateLimitInput{
+				Namespace: namespace,
+				IpAddress: r.RemoteAddr,
+				Rate:      rate,
+				Period:    period,
+			})
+
+			if err != nil {
+				h.presentTooManyRequests(w, r, err)
+				return
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
-
-		if err != nil {
-			h.presentTooManyRequests(w, r, err)
-			return
-		}
-
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
+	}
 }

--- a/api/http/trace_id.go
+++ b/api/http/trace_id.go
@@ -2,11 +2,10 @@ package http
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"net/http"
 
 	"github.com/daochanio/backend/common"
+	"github.com/google/uuid"
 )
 
 // add a randomly generated trace id to the context
@@ -15,7 +14,7 @@ import (
 func (h *httpServer) traceID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		traceID := fmt.Sprintf("%10d", rand.Intn(10000000000))
+		traceID := uuid.New().String()
 		ctx = context.WithValue(ctx, common.ContextKeyTraceID, traceID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/api/usecases/verify_rate_limit.go
+++ b/api/usecases/verify_rate_limit.go
@@ -2,6 +2,8 @@ package usecases
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/daochanio/backend/api/gateways"
 	"github.com/daochanio/backend/common"
@@ -23,7 +25,10 @@ type VerifyRateLimitUseCase struct {
 }
 
 type VerifyRateLimitInput struct {
-	IpAddress string `validate:"required,ip"`
+	Namespace string        `validate:"min=1,max=100"`
+	IpAddress string        `validate:"ip"`
+	Rate      int           `validate:"gt=0"`
+	Period    time.Duration `validate:"gt=0"`
 }
 
 func (u *VerifyRateLimitUseCase) Execute(ctx context.Context, input *VerifyRateLimitInput) error {
@@ -31,7 +36,9 @@ func (u *VerifyRateLimitUseCase) Execute(ctx context.Context, input *VerifyRateL
 		return err
 	}
 
-	if err := u.cacheGateway.VerifyRateLimit(ctx, input.IpAddress); err != nil {
+	key := fmt.Sprintf("%s:%s", input.Namespace, input.IpAddress)
+
+	if err := u.cacheGateway.VerifyRateLimit(ctx, key, input.Rate, input.Period); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- Making the rate limit customizable with specific rates/periods/namespaces
- Using Chi route groups to better apply specific middleware configurations

Other:
- switching trace id and challenge nonce to use uuids