### PR TITLE
work on handling shutdowns gracefully

### DIFF
--- a/api/controllers/http/http.go
+++ b/api/controllers/http/http.go
@@ -158,7 +158,10 @@ func (h *httpServer) Start(ctx context.Context) {
 
 	h.server = &http.Server{Addr: fmt.Sprintf(":%v", port), Handler: r}
 
-	h.server.ListenAndServe()
+	if err := h.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		h.logger.Error(ctx).Err(err).Msg("http service failed")
+		panic(err)
+	}
 
 	h.logger.Info(ctx).Msg("http service stopped")
 }

--- a/api/controllers/http/http.go
+++ b/api/controllers/http/http.go
@@ -18,10 +18,12 @@ import (
 )
 
 type HttpServer interface {
-	Start(context.Context) error
+	Start(context.Context)
+	Stop(ctx context.Context) error
 }
 
 type httpServer struct {
+	server        *http.Server
 	logger        common.Logger
 	settings      settings.Settings
 	getChallenge  *usecases.GetChallenge
@@ -55,7 +57,9 @@ func NewHttpServer(
 	getComments *usecases.GetComments,
 	deleteComment *usecases.DeleteComment,
 	uploadImage *usecases.UploadImage) HttpServer {
+	var server *http.Server
 	return &httpServer{
+		server,
 		logger,
 		settings,
 		getChallenge,
@@ -74,7 +78,7 @@ func NewHttpServer(
 	}
 }
 
-func (h *httpServer) Start(ctx context.Context) error {
+func (h *httpServer) Start(ctx context.Context) {
 	h.logger.Info(ctx).Msg("starting http service")
 
 	r := chi.NewRouter()
@@ -152,11 +156,20 @@ func (h *httpServer) Start(ctx context.Context) error {
 
 	h.logger.Info(ctx).Msgf("listening on port %v", port)
 
-	err := http.ListenAndServe(fmt.Sprintf(":%v", port), r)
+	h.server = &http.Server{Addr: fmt.Sprintf(":%v", port), Handler: r}
 
-	h.logger.Error(ctx).Err(err).Msg("error in http service")
+	h.server.ListenAndServe()
 
-	return err
+	h.logger.Info(ctx).Msg("http service stopped")
+}
+
+func (h *httpServer) Stop(ctx context.Context) error {
+	h.logger.Info(ctx).Msg("cleaning up http service")
+
+	if h.server != nil {
+		return h.server.Shutdown(ctx)
+	}
+	return nil
 }
 
 func (h *httpServer) presentNotFound(w http.ResponseWriter, r *http.Request, err error) {

--- a/api/controllers/subscribe/subscribe.go
+++ b/api/controllers/subscribe/subscribe.go
@@ -15,7 +15,8 @@ import (
 )
 
 type Subscriber interface {
-	Start(ctx context.Context) error
+	Start(ctx context.Context)
+	Stop(ctx context.Context) error
 }
 
 type subscriber struct {
@@ -57,9 +58,9 @@ func NewSubscriber(logger common.Logger, settings settings.Settings, commonSetti
 // We flush the buffer at a certain length or past a certain number of seconds.
 // We can't assume that the messages we are reading in order, since streams are processed in parallel from multiple distributed processes.
 // Example: autoclaiming a vote message from the PEL that Node 1 failed to process but is older than a message that Node 2 is currently processing.
-//
-// TODO: If we receive a sigterm and there are messages in the buffer, flush the buffer and ensure it finishes before exiting
-func (s *subscriber) Start(ctx context.Context) error {
+func (s *subscriber) Start(ctx context.Context) {
+	s.logger.Info(ctx).Msg("starting subscriber")
+
 	group := s.commonSettings.Appname()
 	consumer := s.commonSettings.Hostname()
 
@@ -67,19 +68,35 @@ func (s *subscriber) Start(ctx context.Context) error {
 	_ = s.client.XGroupCreateMkStream(ctx, common.VoteStream, group, "$").Err()
 
 	for {
-		if len(*s.messageBuffer) >= 1000 || (time.Since(s.lastFlush) > time.Second*15 && len(*s.messageBuffer) > 0) {
-			s.flushBuffer(ctx)
+		select {
+		case <-ctx.Done():
+			s.logger.Info(ctx).Msg("subscriber stopped")
+			return
+		default:
+			s.execute(ctx, group, consumer)
 		}
-
-		results, err := s.readMessages(ctx, group, consumer)
-
-		if err != nil {
-			s.logger.Error(ctx).Err(err).Msg("error reading messages from streams")
-			continue
-		}
-
-		s.bufferMessages(ctx, group, results)
 	}
+}
+
+func (s *subscriber) Stop(ctx context.Context) error {
+	s.logger.Info(ctx).Msg("cleaning up subscriber")
+	s.flushBuffer(ctx)
+	return nil
+}
+
+func (s *subscriber) execute(ctx context.Context, group string, consumer string) {
+	if len(*s.messageBuffer) >= 1000 || (time.Since(s.lastFlush) > time.Second*15 && len(*s.messageBuffer) > 0) {
+		s.flushBuffer(ctx)
+	}
+
+	results, err := s.readMessages(ctx, group, consumer)
+
+	if err != nil {
+		s.logger.Error(ctx).Err(err).Msg("error reading messages from streams")
+		return
+	}
+
+	s.bufferMessages(ctx, group, results)
 }
 
 // Reads messages from the streams starting by checking the pending messages that are unacknowledged
@@ -112,7 +129,7 @@ func (s *subscriber) readMessages(ctx context.Context, group string, consumer st
 		Group:    group,
 		Consumer: consumer,
 		Streams:  []string{common.SigninStream, common.VoteStream, ">", ">"},
-		Block:    time.Second * 10,
+		Block:    time.Second * 10, // This value should be tied to the value specified in main.go's awaitSigterm
 		Count:    100,
 	}).Result()
 

--- a/api/controllers/subscribe/subscribe.go
+++ b/api/controllers/subscribe/subscribe.go
@@ -16,7 +16,7 @@ import (
 
 type Subscriber interface {
 	Start(ctx context.Context)
-	Stop(ctx context.Context) error
+	Stop(ctx context.Context)
 }
 
 type subscriber struct {
@@ -78,10 +78,9 @@ func (s *subscriber) Start(ctx context.Context) {
 	}
 }
 
-func (s *subscriber) Stop(ctx context.Context) error {
+func (s *subscriber) Stop(ctx context.Context) {
 	s.logger.Info(ctx).Msg("cleaning up subscriber")
 	s.flushBuffer(ctx)
-	return nil
 }
 
 func (s *subscriber) execute(ctx context.Context, group string, consumer string) {

--- a/api/main.go
+++ b/api/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/daochanio/backend/api/controllers/http"
 	"github.com/daochanio/backend/api/controllers/subscribe"
@@ -20,7 +20,10 @@ import (
 )
 
 func main() {
-	container := newContainer()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	container := newContainer(ctx)
 
 	// start the http controller inside a go routine
 	if err := container.Invoke(startHttpServer); err != nil {
@@ -38,13 +41,17 @@ func main() {
 	}
 }
 
-func newContainer() *dig.Container {
+func newContainer(ctx context.Context) *dig.Container {
 	container := dig.New()
 
-	if err := container.Provide(context.Background); err != nil {
+	if err := container.Provide(func() context.Context {
+		return ctx
+	}); err != nil {
 		panic(err)
 	}
-	if err := container.Provide(appName); err != nil {
+	if err := container.Provide(func() string {
+		return "api"
+	}); err != nil {
 		panic(err)
 	}
 	if err := container.Provide(common.NewCommonSettings); err != nil {
@@ -131,30 +138,37 @@ func newContainer() *dig.Container {
 	return container
 }
 
-func appName() string {
-	return "api"
-}
-
 func startHttpServer(ctx context.Context, httpServer http.HttpServer) {
 	go func() {
-		err := httpServer.Start(ctx)
-		panic(err)
+		httpServer.Start(ctx)
 	}()
 }
 
 func startSubscriber(ctx context.Context, subscriber subscribe.Subscriber) {
 	go func() {
-		err := subscriber.Start(ctx)
-		panic(err)
+		subscriber.Start(ctx)
 	}()
 }
 
-func awaitSigterm(ctx context.Context, logger common.Logger) {
-	logger.Info(ctx).Msg("awaiting sigterm")
+func awaitSigterm(ctx context.Context, logger common.Logger, httpServer http.HttpServer, subscriber subscribe.Subscriber) {
+	logger.Info(ctx).Msg("awaiting kill signal")
 
-	cancelChan := make(chan os.Signal, 1)
-	signal.Notify(cancelChan, syscall.SIGTERM, syscall.SIGINT)
-	sig := <-cancelChan
+	<-ctx.Done()
 
-	logger.Info(ctx).Msgf("received sigterm %v", sig)
+	logger.Info(ctx).Msgf("received kill signal, beginning shutdown")
+
+	shutdownCtx := context.Background()
+
+	httpServer.Stop(shutdownCtx)
+
+	// FIXME:
+	// See https://github.com/redis/go-redis/issues/2276 and https://github.com/redis/go-redis/pull/2455
+	// Blocking calls to redis client methods will not be interrupted by the shutdown context.
+	// We need to wait before calling Stop() to ensure that the subscriber has finished processing its latest loop before we call Stop().
+	// This way we ensure that no new messages will be written to the buffer after flushing inside the Stop() method.
+	time.Sleep(10 * time.Second)
+
+	subscriber.Stop(shutdownCtx)
+
+	logger.Info(ctx).Msgf("shutdown complete")
 }

--- a/distributor/main.go
+++ b/distributor/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/daochanio/backend/common"
 	"github.com/daochanio/backend/distributor/controllers/distribute"
@@ -14,12 +14,19 @@ import (
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	container := dig.New()
 
-	if err := container.Provide(context.Background); err != nil {
+	if err := container.Provide(func() context.Context {
+		return ctx
+	}); err != nil {
 		panic(err)
 	}
-	if err := container.Provide(appName); err != nil {
+	if err := container.Provide(func() string {
+		return "distributor"
+	}); err != nil {
 		panic(err)
 	}
 	if err := container.Provide(common.NewCommonSettings); err != nil {
@@ -53,34 +60,33 @@ func main() {
 	}
 }
 
-func appName() string {
-	return "distributor"
-}
-
 func startDistributor(ctx context.Context, distributor distribute.Distributor, logger common.Logger) {
 	go func() {
-		if err := distributor.Start(ctx); err != nil {
-			logger.Error(ctx).Err(err).Msg("distributor stopped")
-			panic(err)
-		}
+		distributor.Start(ctx)
 	}()
 }
 
 func startMessageSubscriber(ctx context.Context, subscriber subscribe.Subscriber, logger common.Logger) {
 	go func() {
-		if err := subscriber.Start(ctx); err != nil {
-			logger.Error(ctx).Err(err).Msg("subscriber stopped")
-			panic(err)
-		}
+		subscriber.Start(ctx)
 	}()
 }
 
-func awaitSigterm(ctx context.Context, logger common.Logger) {
-	logger.Info(ctx).Msg("awaiting sigterm")
+func awaitSigterm(ctx context.Context, logger common.Logger, distributor distribute.Distributor, subscriber subscribe.Subscriber) {
+	logger.Info(ctx).Msg("awaiting kill signal")
 
-	cancelChan := make(chan os.Signal, 1)
-	signal.Notify(cancelChan, syscall.SIGTERM, syscall.SIGINT)
-	sig := <-cancelChan
+	<-ctx.Done()
 
-	logger.Info(ctx).Msgf("received signal %v", sig)
+	logger.Info(ctx).Msgf("received kill signal, beginning shutdown")
+
+	shutdownCtx := context.Background()
+
+	// Allow distributor to finish if its currently in the middle of processing
+	time.Sleep(time.Second * 10)
+
+	distributor.Stop(shutdownCtx)
+
+	subscriber.Stop(shutdownCtx)
+
+	logger.Info(ctx).Msgf("shutdown complete")
 }

--- a/distributor/main.go
+++ b/distributor/main.go
@@ -77,7 +77,7 @@ func awaitSigterm(ctx context.Context, logger common.Logger, distributor distrib
 
 	<-ctx.Done()
 
-	logger.Info(ctx).Msgf("received kill signal, beginning shutdown")
+	logger.Info(ctx).Msgf("received kill signal")
 
 	shutdownCtx := context.Background()
 

--- a/indexer/main.go
+++ b/indexer/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/daochanio/backend/common"
 	"github.com/daochanio/backend/indexer/controllers/index"
@@ -16,12 +16,19 @@ import (
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	container := dig.New()
 
-	if err := container.Provide(context.Background); err != nil {
+	if err := container.Provide(func() context.Context {
+		return ctx
+	}); err != nil {
 		panic(err)
 	}
-	if err := container.Provide(appName); err != nil {
+	if err := container.Provide(func() string {
+		return "indexer"
+	}); err != nil {
 		panic(err)
 	}
 	if err := container.Provide(common.NewCommonSettings); err != nil {
@@ -60,26 +67,25 @@ func main() {
 	}
 }
 
-func appName() string {
-	return "indexer"
-}
-
 func startIndexer(ctx context.Context, indexer index.Indexer, logger common.Logger) {
 	go func() {
-		// blocking call to start the indexer
-		if err := indexer.Start(ctx); err != nil {
-			logger.Error(ctx).Err(err).Msg("indexer stopped")
-			panic(err)
-		}
+		indexer.Start(ctx)
 	}()
 }
 
-func awaitSigterm(ctx context.Context, logger common.Logger) {
-	logger.Info(ctx).Msg("awaiting sigterm")
+func awaitSigterm(ctx context.Context, logger common.Logger, indexer index.Indexer, settings settings.Settings) {
+	logger.Info(ctx).Msg("awaiting kill signal")
 
-	cancelChan := make(chan os.Signal, 1)
-	signal.Notify(cancelChan, syscall.SIGTERM, syscall.SIGINT)
-	sig := <-cancelChan
+	<-ctx.Done()
 
-	logger.Info(ctx).Msgf("received signal %v", sig)
+	logger.Info(ctx).Msgf("received kill signal, beginning shutdown")
+
+	// allow indexer to finish if its currently in the middle of indexing
+	time.Sleep(time.Second * 10)
+
+	stopCtx := context.Background()
+
+	indexer.Stop(stopCtx)
+
+	logger.Info(ctx).Msgf("shutdown complete")
 }

--- a/indexer/main.go
+++ b/indexer/main.go
@@ -78,7 +78,7 @@ func awaitSigterm(ctx context.Context, logger common.Logger, indexer index.Index
 
 	<-ctx.Done()
 
-	logger.Info(ctx).Msgf("received kill signal, beginning shutdown")
+	logger.Info(ctx).Msgf("received kill signal")
 
 	// allow indexer to finish if its currently in the middle of indexing
 	time.Sleep(time.Second * 10)


### PR DESCRIPTION
Leveraging signals NotifyContext method to derive a context that will be marked as done when a kill signal is received from the container orchestrator. Adding logic to watch for the context being marked as done within the various goroutines (http, subscriber, distributor, indexer, etc) to gracefull stop their blocking calls. Adding logic once the context is marked as done to call Stop methods on all controllers to allow for any extra resource cleanup to be done. We generally wait 10 seconds between context being marked as done and calling stop to ensure that each go routine has time to observe the context being marked as done. This is particularly important for Subscribers because there is currently a bug in the Redis client that will not cancel blocking calls when context is marked as done. 

In the context of the http controller Stop allows for server.Shutdown to be called which will gracefully shutdown the server without interrupting active connections. 

In the context of the api subscriber this allows us to flush the buffer in the event that it still has items in its buffer after observing the context as done and returning.