### PR TITLE
Adding get user endpoint and middleware to enforce ens name existance for endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-indexer:
 	go build -o bin/indexer ./indexer/
 
 run-api:
-	ENV=dev go run api/main.go
+	ENV=dev go run api/*.go
 
 run-distributor:
 	ENV=dev go run distributor/main.go

--- a/api/container.go
+++ b/api/container.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+
+	"github.com/daochanio/backend/api/controllers/http"
+	"github.com/daochanio/backend/api/controllers/subscribe"
+	"github.com/daochanio/backend/api/gateways/ethereum"
+	"github.com/daochanio/backend/api/gateways/postgres"
+	"github.com/daochanio/backend/api/gateways/redis"
+	"github.com/daochanio/backend/api/gateways/s3"
+	"github.com/daochanio/backend/api/gateways/worker"
+	"github.com/daochanio/backend/api/settings"
+	"github.com/daochanio/backend/api/usecases"
+	"github.com/daochanio/backend/common"
+	"go.uber.org/dig"
+)
+
+func newContainer(ctx context.Context, appName string) *dig.Container {
+	container := dig.New()
+
+	if err := container.Provide(func() context.Context {
+		return ctx
+	}); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(func() string {
+		return appName
+	}); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(common.NewCommonSettings); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(common.NewLogger); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(common.NewHttpClient); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(settings.NewSettings); err != nil {
+		panic(err)
+	}
+
+	provideGateways(container)
+	provideUseCases(container)
+	provideControllers(container)
+
+	return container
+}
+
+func provideGateways(container *dig.Container) {
+	if err := container.Provide(postgres.NewDatabaseGateway); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(redis.NewCacheGateway); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(redis.NewStreamGateway); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(s3.NewStorageGateway); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(worker.NewSafeProxyGateway); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(ethereum.NewBlockchainGateway); err != nil {
+		panic(err)
+	}
+}
+
+func provideUseCases(container *dig.Container) {
+	if err := container.Provide(usecases.NewVerifyRateLimitUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewGetChallengeUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewAuthenticateUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewSigninUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewGetThreadUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewGetThreadsUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewCreateThreadUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewDeleteThreadUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewCreateVoteUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewGetCommentsUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewCreateCommentUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewDeleteCommentUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewUploadImageUsecase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewAggregateVotesUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewHydrateUsersUseCase); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(usecases.NewGetUserUseCase); err != nil {
+		panic(err)
+	}
+}
+
+func provideControllers(container *dig.Container) {
+	if err := container.Provide(http.NewHttpServer); err != nil {
+		panic(err)
+	}
+	if err := container.Provide(subscribe.NewSubscriber); err != nil {
+		panic(err)
+	}
+}

--- a/api/controllers/http/authentication.go
+++ b/api/controllers/http/authentication.go
@@ -10,7 +10,7 @@ import (
 	"github.com/daochanio/backend/common"
 )
 
-func (h *httpServer) authenticator(next http.Handler) http.Handler {
+func (h *httpServer) authentication(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		token := strings.Split(r.Header.Get("Authorization"), " ")
@@ -29,7 +29,16 @@ func (h *httpServer) authenticator(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx = context.WithValue(ctx, common.ContextKeyAddress, address)
+		user, err := h.getUser.Execute(ctx, usecases.GetUserInput{
+			Address: address,
+		})
+
+		if err != nil {
+			h.presentUnathorized(w, r, err)
+			return
+		}
+
+		ctx = context.WithValue(ctx, common.ContextKeyUser, user)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/api/controllers/http/comments.go
+++ b/api/controllers/http/comments.go
@@ -74,10 +74,17 @@ func (h *httpServer) createCommentRoute(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+	if !ok {
+		h.presentBadRequest(w, r, fmt.Errorf("invalid user"))
+		return
+	}
+
 	comment, err := h.createComment.Execute(ctx, usecases.CreateCommentInput{
 		RepliedToCommentId: repliedToCommentId,
 		ThreadId:           threadId,
-		Address:            ctx.Value(common.ContextKeyAddress).(string),
+		Address:            user.Address(),
 		Content:            body.Content,
 		ImageFileName:      body.ImageFileName,
 	})
@@ -97,11 +104,19 @@ func (h *httpServer) deleteCommentRoute(w http.ResponseWriter, r *http.Request) 
 
 	if err != nil {
 		h.presentBadRequest(w, r, err)
+		return
+	}
+
+	user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+	if !ok {
+		h.presentBadRequest(w, r, fmt.Errorf("invalid user"))
+		return
 	}
 
 	err = h.deleteComment.Execute(ctx, usecases.DeleteCommentInput{
 		Id:             id,
-		DeleterAddress: ctx.Value(common.ContextKeyAddress).(string),
+		DeleterAddress: user.Address(),
 	})
 
 	if errors.Is(err, common.ErrNotFound) {
@@ -125,11 +140,19 @@ func (h *httpServer) createCommentVoteRoute(w http.ResponseWriter, r *http.Reque
 
 	if err != nil {
 		h.presentBadRequest(w, r, err)
+		return
+	}
+
+	user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+	if !ok {
+		h.presentBadRequest(w, r, fmt.Errorf("invalid user"))
+		return
 	}
 
 	err = h.createVote.Execute(ctx, usecases.CreateVoteInput{
 		Id:      id,
-		Address: ctx.Value(common.ContextKeyAddress).(string),
+		Address: user.Address(),
 		Value:   common.VoteValue(value),
 		Type:    common.CommentVote,
 	})

--- a/api/controllers/http/ensname.go
+++ b/api/controllers/http/ensname.go
@@ -1,0 +1,29 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/daochanio/backend/api/entities"
+	"github.com/daochanio/backend/common"
+)
+
+// ensure the user has an ens name before proceeding
+func (h *httpServer) ensName(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+		if !ok {
+			h.presentForbidden(w, r, fmt.Errorf("invalid user"))
+			return
+		}
+
+		if user.EnsName() == nil || *user.EnsName() == "" {
+			h.presentForbidden(w, r, fmt.Errorf("ens name required"))
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/api/controllers/http/threads.go
+++ b/api/controllers/http/threads.go
@@ -79,8 +79,15 @@ func (h *httpServer) createThreadRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+	if !ok {
+		h.presentBadRequest(w, r, fmt.Errorf("invalid user"))
+		return
+	}
+
 	thread, err := h.createThread.Execute(ctx, usecases.CreateThreadInput{
-		Address:       ctx.Value(common.ContextKeyAddress).(string),
+		Address:       user.Address(),
 		Title:         body.Title,
 		ImageFileName: body.ImageFileName,
 		Content:       body.Content,
@@ -100,11 +107,19 @@ func (h *httpServer) deleteThreadRoute(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		h.presentBadRequest(w, r, err)
+		return
+	}
+
+	user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+	if !ok {
+		h.presentBadRequest(w, r, fmt.Errorf("invalid user"))
+		return
 	}
 
 	err = h.deleteThread.Execute(ctx, usecases.DeleteThreadInput{
 		ThreadId:       id,
-		DeleterAddress: ctx.Value(common.ContextKeyAddress).(string),
+		DeleterAddress: user.Address(),
 	})
 
 	if errors.Is(err, common.ErrNotFound) {
@@ -129,9 +144,16 @@ func (h *httpServer) createThreadVoteRoute(w http.ResponseWriter, r *http.Reques
 		h.presentBadRequest(w, r, err)
 	}
 
+	user, ok := ctx.Value(common.ContextKeyUser).(entities.User)
+
+	if !ok {
+		h.presentBadRequest(w, r, fmt.Errorf("invalid user"))
+		return
+	}
+
 	err = h.createVote.Execute(ctx, usecases.CreateVoteInput{
 		Id:      id,
-		Address: ctx.Value(common.ContextKeyAddress).(string),
+		Address: user.Address(),
 		Value:   common.VoteValue(value),
 		Type:    common.ThreadVote,
 	})

--- a/api/controllers/http/users.go
+++ b/api/controllers/http/users.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/daochanio/backend/api/entities"
+	"github.com/daochanio/backend/api/usecases"
+	"github.com/daochanio/backend/common"
+	"github.com/go-chi/chi/v5"
+)
+
+func (h *httpServer) getUserByAddressRoute(w http.ResponseWriter, r *http.Request) {
+	user, err := h.getUser.Execute(r.Context(), usecases.GetUserInput{
+		Address: chi.URLParam(r, "address"),
+	})
+
+	if errors.Is(err, common.ErrNotFound) {
+		h.presentNotFound(w, r, err)
+		return
+	}
+
+	if err != nil {
+		h.presentBadRequest(w, r, err)
+		return
+	}
+
+	h.presentJSON(w, r, http.StatusOK, toUserJson(user), nil)
+}
+
+type userJson struct {
+	Address    string     `json:"address"`
+	EnsName    *string    `json:"ensName,omitempty"`
+	EnsAvatar  *imageJson `json:"ensAvatar,omitempty"`
+	Reputation string     `json:"reputation"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  *time.Time `json:"updatedAt,omitempty"`
+}
+
+func toUserJson(user entities.User) userJson {
+	return userJson{
+		Address:    user.Address(),
+		EnsName:    user.EnsName(),
+		EnsAvatar:  toImageJson(user.EnsAvatar()),
+		Reputation: fmt.Sprint(user.Reputation()),
+		CreatedAt:  user.CreatedAt(),
+		UpdatedAt:  user.UpdatedAt(),
+	}
+}

--- a/api/entities/user.go
+++ b/api/entities/user.go
@@ -3,25 +3,31 @@ package entities
 import "time"
 
 type User struct {
-	address   string
-	ensName   *string
-	createdAt time.Time
-	updatedAt time.Time
+	address    string
+	ensName    *string
+	ensAvatar  *Image
+	reputation int64
+	createdAt  time.Time
+	updatedAt  *time.Time
 }
 
 type UserParams struct {
-	Address   string
-	EnsName   *string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	Address    string
+	EnsName    *string
+	EnsAvatar  *Image
+	Reputation int64
+	CreatedAt  time.Time
+	UpdatedAt  *time.Time
 }
 
 func NewUser(params UserParams) User {
 	return User{
-		address:   params.Address,
-		ensName:   params.EnsName,
-		createdAt: params.CreatedAt,
-		updatedAt: params.UpdatedAt,
+		address:    params.Address,
+		ensName:    params.EnsName,
+		ensAvatar:  params.EnsAvatar,
+		reputation: params.Reputation,
+		createdAt:  params.CreatedAt,
+		updatedAt:  params.UpdatedAt,
 	}
 }
 
@@ -33,10 +39,18 @@ func (u *User) EnsName() *string {
 	return u.ensName
 }
 
+func (u *User) EnsAvatar() *Image {
+	return u.ensAvatar
+}
+
+func (u *User) Reputation() int64 {
+	return u.reputation
+}
+
 func (u *User) CreatedAt() time.Time {
 	return u.createdAt
 }
 
-func (u *User) UpdatedAt() time.Time {
+func (u *User) UpdatedAt() *time.Time {
 	return u.updatedAt
 }

--- a/api/gateways/postgres/comments.go
+++ b/api/gateways/postgres/comments.go
@@ -2,13 +2,13 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"time"
 
 	"github.com/daochanio/backend/api/entities"
 	"github.com/daochanio/backend/common"
 	"github.com/daochanio/backend/db/bindings"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -132,7 +132,7 @@ func (p *postgresGateway) GetComments(ctx context.Context, threadId int64, offse
 func (p *postgresGateway) GetCommentById(ctx context.Context, id int64) (entities.Comment, error) {
 	comment, err := p.queries.GetComment(ctx, id)
 
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return entities.Comment{}, common.ErrNotFound
 	}
 
@@ -164,7 +164,7 @@ func (p *postgresGateway) GetCommentById(ctx context.Context, id int64) (entitie
 func (p *postgresGateway) DeleteComment(ctx context.Context, id int64) error {
 	_, err := p.queries.DeleteComment(ctx, id)
 
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return common.ErrNotFound
 	}
 

--- a/api/gateways/postgres/threads.go
+++ b/api/gateways/postgres/threads.go
@@ -2,13 +2,13 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"time"
 
 	"github.com/daochanio/backend/api/entities"
 	"github.com/daochanio/backend/common"
 	"github.com/daochanio/backend/db/bindings"
+	"github.com/jackc/pgx/v5"
 )
 
 func (p *postgresGateway) CreateThread(ctx context.Context, thread entities.Thread) (entities.Thread, error) {
@@ -79,7 +79,7 @@ func (p *postgresGateway) GetThreads(ctx context.Context, limit int64) ([]entiti
 func (p *postgresGateway) GetThreadById(ctx context.Context, id int64) (entities.Thread, error) {
 	thread, err := p.queries.GetThread(ctx, id)
 
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return entities.Thread{}, common.ErrNotFound
 	}
 
@@ -110,7 +110,7 @@ func (p *postgresGateway) GetThreadById(ctx context.Context, id int64) (entities
 func (p *postgresGateway) DeleteThread(ctx context.Context, id int64) error {
 	_, err := p.queries.DeleteThread(ctx, id)
 
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return common.ErrNotFound
 	}
 

--- a/api/gateways/postgres/users.go
+++ b/api/gateways/postgres/users.go
@@ -2,11 +2,52 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/daochanio/backend/api/entities"
+	"github.com/daochanio/backend/common"
 	"github.com/daochanio/backend/db/bindings"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+func (p *postgresGateway) GetUserByAddress(ctx context.Context, address string) (entities.User, error) {
+	user, err := p.queries.GetUser(ctx, address)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return entities.User{}, common.ErrNotFound
+	}
+
+	if err != nil {
+		return entities.User{}, err
+	}
+
+	var ensName *string
+	if user.EnsName.Valid {
+		ensName = &user.EnsName.String
+	}
+
+	var ensAvatar *entities.Image
+	if user.EnsAvatarUrl.Valid {
+		image := entities.NewImage(user.EnsAvatarFileName.String, user.EnsAvatarUrl.String, user.EnsAvatarContentType.String)
+		ensAvatar = &image
+	}
+
+	var updatedAt *time.Time
+	if user.UpdatedAt.Valid {
+		updatedAt = &user.UpdatedAt.Time
+	}
+
+	return entities.NewUser(entities.UserParams{
+		Address:    user.Address,
+		EnsName:    ensName,
+		EnsAvatar:  ensAvatar,
+		Reputation: user.Reputation,
+		CreatedAt:  user.CreatedAt.Time,
+		UpdatedAt:  updatedAt,
+	}), nil
+}
 
 func (p *postgresGateway) UpsertUser(ctx context.Context, address string) error {
 	return p.queries.UpsertUser(ctx, address)

--- a/api/main.go
+++ b/api/main.go
@@ -129,6 +129,9 @@ func newContainer(ctx context.Context) *dig.Container {
 	if err := container.Provide(usecases.NewHydrateUsersUseCase); err != nil {
 		panic(err)
 	}
+	if err := container.Provide(usecases.NewGetUserUseCase); err != nil {
+		panic(err)
+	}
 	if err := container.Provide(http.NewHttpServer); err != nil {
 		panic(err)
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -8,137 +8,26 @@ import (
 
 	"github.com/daochanio/backend/api/controllers/http"
 	"github.com/daochanio/backend/api/controllers/subscribe"
-	"github.com/daochanio/backend/api/gateways/ethereum"
-	"github.com/daochanio/backend/api/gateways/postgres"
-	"github.com/daochanio/backend/api/gateways/redis"
-	"github.com/daochanio/backend/api/gateways/s3"
-	"github.com/daochanio/backend/api/gateways/worker"
-	"github.com/daochanio/backend/api/settings"
-	"github.com/daochanio/backend/api/usecases"
 	"github.com/daochanio/backend/common"
-	"go.uber.org/dig"
 )
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	container := newContainer(ctx)
+	container := newContainer(ctx, "api")
 
-	// start the http controller inside a go routine
 	if err := container.Invoke(startHttpServer); err != nil {
 		panic(err)
 	}
 
-	// start the message subscriber inside a go routine
 	if err := container.Invoke(startSubscriber); err != nil {
 		panic(err)
 	}
 
-	// blocking call in main go routine to await sigterm
 	if err := container.Invoke(awaitSigterm); err != nil {
 		panic(err)
 	}
-}
-
-func newContainer(ctx context.Context) *dig.Container {
-	container := dig.New()
-
-	if err := container.Provide(func() context.Context {
-		return ctx
-	}); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(func() string {
-		return "api"
-	}); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(common.NewCommonSettings); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(common.NewLogger); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(common.NewHttpClient); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(settings.NewSettings); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(postgres.NewDatabaseGateway); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(redis.NewCacheGateway); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(redis.NewStreamGateway); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(s3.NewStorageGateway); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(worker.NewSafeProxyGateway); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(ethereum.NewBlockchainGateway); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewVerifyRateLimitUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewGetChallengeUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewAuthenticateUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewSigninUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewGetThreadUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewGetThreadsUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewCreateThreadUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewDeleteThreadUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewCreateVoteUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewGetCommentsUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewCreateCommentUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewDeleteCommentUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewUploadImageUsecase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewAggregateVotesUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewHydrateUsersUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(usecases.NewGetUserUseCase); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(http.NewHttpServer); err != nil {
-		panic(err)
-	}
-	if err := container.Provide(subscribe.NewSubscriber); err != nil {
-		panic(err)
-	}
-	return container
 }
 
 func startHttpServer(ctx context.Context, httpServer http.HttpServer) {

--- a/api/usecases/authenticate.go
+++ b/api/usecases/authenticate.go
@@ -11,13 +11,11 @@ import (
 
 type Authenticate struct {
 	settings settings.Settings
-	cache    Cache
 }
 
-func NewAuthenticateUseCase(settings settings.Settings, cache Cache) *Authenticate {
+func NewAuthenticateUseCase(settings settings.Settings) *Authenticate {
 	return &Authenticate{
 		settings,
-		cache,
 	}
 }
 
@@ -46,7 +44,11 @@ func (u *Authenticate) Execute(ctx context.Context, input *AuthenticateInput) (s
 		return "", fmt.Errorf("invalid token")
 	}
 
-	claims := token.Claims.(jwt.MapClaims)
+	claims, ok := token.Claims.(jwt.MapClaims)
+
+	if !ok {
+		return "", fmt.Errorf("invalid claims")
+	}
 
 	return claims.GetSubject()
 }

--- a/api/usecases/gateways.go
+++ b/api/usecases/gateways.go
@@ -12,6 +12,7 @@ type Database interface {
 	GetChallengeByAddress(ctx context.Context, address string) (entities.Challenge, error)
 	SaveChallenge(ctx context.Context, challenge entities.Challenge) error
 
+	GetUserByAddress(ctx context.Context, address string) (entities.User, error)
 	GetThreads(ctx context.Context, limit int64) ([]entities.Thread, error)
 	GetThreadById(ctx context.Context, threadId int64) (entities.Thread, error)
 	GetComments(ctx context.Context, threadId int64, offset int64, limit int64) ([]entities.Comment, int64, error)

--- a/api/usecases/getuser.go
+++ b/api/usecases/getuser.go
@@ -1,0 +1,34 @@
+package usecases
+
+import (
+	"context"
+
+	"github.com/daochanio/backend/api/entities"
+	"github.com/daochanio/backend/common"
+)
+
+type GetUser struct {
+	logger   common.Logger
+	database Database
+}
+
+func NewGetUserUseCase(logger common.Logger, database Database) *GetUser {
+	return &GetUser{
+		logger,
+		database,
+	}
+}
+
+type GetUserInput struct {
+	Address string `validate:"eth_addr"`
+}
+
+func (g *GetUser) Execute(ctx context.Context, input GetUserInput) (entities.User, error) {
+	user, err := g.database.GetUserByAddress(ctx, input.Address)
+
+	if err != nil {
+		return entities.User{}, err
+	}
+
+	return user, nil
+}

--- a/common/context.go
+++ b/common/context.go
@@ -12,5 +12,5 @@ var (
 	ContextKeyTraceID          = ContextKey("request id")
 	ContextKeyRequestStartTime = ContextKey("request start time")
 	ContextKeyRemoteAddress    = ContextKey("request remote address")
-	ContextKeyAddress          = ContextKey("address")
+	ContextKeyUser             = ContextKey("user")
 )

--- a/db/bindings/api.sql.go
+++ b/db/bindings/api.sql.go
@@ -468,6 +468,28 @@ func (q *Queries) GetThreads(ctx context.Context, dollar_1 int64) ([]Thread, err
 	return items, nil
 }
 
+const getUser = `-- name: GetUser :one
+SELECT address, ens_name, created_at, updated_at, reputation, ens_avatar_file_name, ens_avatar_url, ens_avatar_content_type
+FROM users
+WHERE address = $1
+`
+
+func (q *Queries) GetUser(ctx context.Context, address string) (User, error) {
+	row := q.db.QueryRow(ctx, getUser, address)
+	var i User
+	err := row.Scan(
+		&i.Address,
+		&i.EnsName,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Reputation,
+		&i.EnsAvatarFileName,
+		&i.EnsAvatarUrl,
+		&i.EnsAvatarContentType,
+	)
+	return i, err
+}
+
 const updateChallenge = `-- name: UpdateChallenge :exec
 INSERT INTO challenges (address, message, expires_at)
 VALUES ($1, $2, $3)

--- a/db/migrations/20230522131456_user_updated_at.sql
+++ b/db/migrations/20230522131456_user_updated_at.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- alter users table to make updated_at column nullable and default null
+ALTER TABLE users ALTER COLUMN updated_at DROP NOT NULL;
+ALTER TABLE users ALTER COLUMN updated_at DROP DEFAULT;
+
+-- +goose StatementEnd

--- a/db/queries/api.sql
+++ b/db/queries/api.sql
@@ -1,3 +1,8 @@
+-- name: GetUser :one
+SELECT *
+FROM users
+WHERE address = $1;
+
 -- upsert user every time they signin so we don't have to check if they exist
 -- name: UpsertUser :exec
 INSERT INTO users (address)


### PR DESCRIPTION
- Adding get user endpoint
- Fetching user in authentication middleware and adding to context
- Introducing EnsName middleware to ensure users have an ens name for voting/posting
- Updating UpdatedAt column on Users entity to be nullable to allow front end to infer whether the user has been hydrated for the first time or not
- Fixing bug from pgx migration to use correct error for infering empty results
- Fixing bugs in several endpoints to return on bad requests
- Moving container registriation/orchestration into seperate file to help with growing cyclomatic complexity of main