### PR TITLE
More work on graceful startting/stopping

### DIFF
--- a/api/container.go
+++ b/api/container.go
@@ -31,7 +31,7 @@ func provideGeneral(ctx context.Context, container *dig.Container) {
 	}); err != nil {
 		panic(err)
 	}
-	if err := container.Provide(common.NewCommonSettings); err != nil {
+	if err := container.Provide(common.NewSettings); err != nil {
 		panic(err)
 	}
 	if err := container.Provide(common.NewLogger); err != nil {

--- a/api/controllers/http/http.go
+++ b/api/controllers/http/http.go
@@ -19,7 +19,7 @@ import (
 
 type HttpServer interface {
 	Start(context.Context)
-	Stop(ctx context.Context) error
+	Shutdown(ctx context.Context) error
 }
 
 type httpServer struct {
@@ -173,8 +173,8 @@ func (h *httpServer) Start(ctx context.Context) {
 	h.logger.Info(ctx).Msg("http service stopped")
 }
 
-func (h *httpServer) Stop(ctx context.Context) error {
-	h.logger.Info(ctx).Msg("cleaning up http service")
+func (h *httpServer) Shutdown(ctx context.Context) error {
+	h.logger.Info(ctx).Msg("shutting down http service")
 
 	if h.server != nil {
 		return h.server.Shutdown(ctx)

--- a/api/gateways/ethereum/ethereum.go
+++ b/api/gateways/ethereum/ethereum.go
@@ -23,6 +23,10 @@ func NewBlockchainGateway(settings settings.Settings, logger common.Logger) usec
 	}
 }
 
+func (e *ethereumGateway) Start(ctx context.Context) {}
+
+func (e *ethereumGateway) Shutdown(ctx context.Context) {}
+
 // Parse for go-ethereum http error to determine if its retryable.
 // Wrap in common.ErrRetryable if status code is 429 and include msg
 func (e *ethereumGateway) tryWrapRetryable(ctx context.Context, msg string, err error) error {

--- a/api/gateways/s3/s3.go
+++ b/api/gateways/s3/s3.go
@@ -23,13 +23,18 @@ type s3Gateway struct {
 }
 
 func NewStorageGateway(ctx context.Context, logger common.Logger, settings settings.Settings) usecases.Storage {
-	client := s3.NewFromConfig(*settings.S3Config(ctx))
 	return &s3Gateway{
-		logger,
-		settings,
-		client,
+		logger:   logger,
+		settings: settings,
+		client:   nil,
 	}
 }
+
+func (g *s3Gateway) Start(ctx context.Context) {
+	g.client = s3.NewFromConfig(*g.settings.S3Config(ctx))
+}
+
+func (g *s3Gateway) Shutdown(ctx context.Context) {}
 
 func (g *s3Gateway) UploadImage(ctx context.Context, fileName string, contentType string, data *[]byte) (entities.Image, error) {
 	if data == nil {

--- a/api/gateways/worker/worker.go
+++ b/api/gateways/worker/worker.go
@@ -28,6 +28,10 @@ func NewSafeProxyGateway(logger common.Logger, settings settings.Settings, httpC
 	}
 }
 
+func (w *worker) Start(ctx context.Context) {}
+
+func (w *worker) Shutdown(ctx context.Context) {}
+
 func (w *worker) DownloadImage(ctx context.Context, uri string) (*[]byte, string, error) {
 	resp, err := w.safeProxy(ctx, uri)
 

--- a/api/usecases/gateways.go
+++ b/api/usecases/gateways.go
@@ -9,6 +9,9 @@ import (
 )
 
 type Database interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
+
 	GetChallengeByAddress(ctx context.Context, address string) (entities.Challenge, error)
 	SaveChallenge(ctx context.Context, challenge entities.Challenge) error
 
@@ -29,26 +32,36 @@ type Database interface {
 }
 
 type Cache interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	VerifyRateLimit(ctx context.Context, key string, rate int, period time.Duration) error
 }
 
 type Stream interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	PublishSignin(ctx context.Context, address string) error
 	PublishVote(ctx context.Context, vote entities.Vote) error
 }
 
 type Blockchain interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	GetNameByAddress(ctx context.Context, address string) (*string, error)
 	GetAvatarURIByName(ctx context.Context, name string) (*string, error)
 	GetNFTURI(ctx context.Context, standard string, address string, id string) (string, error)
 }
 
 type Storage interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	UploadImage(ctx context.Context, fileName string, contentType string, data *[]byte) (entities.Image, error)
 	GetImageByFileName(ctx context.Context, fileName string) (*entities.Image, error)
 }
 
 type SafeProxy interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	DownloadImage(ctx context.Context, uri string) (*[]byte, string, error)
 	GetNFTImageURI(ctx context.Context, uri string) (string, error)
 }

--- a/common/context.go
+++ b/common/context.go
@@ -2,7 +2,7 @@ package common
 
 type ContextKey string
 
-const contextKeyPrefix = "etheralley context key "
+const contextKeyPrefix = "daochan context key "
 
 func (c ContextKey) String() string {
 	return contextKeyPrefix + string(c)

--- a/common/logger.go
+++ b/common/logger.go
@@ -26,11 +26,11 @@ type LogEvent interface {
 }
 
 type logger struct {
-	appSettings CommonSettings
-	logger      zerolog.Logger
+	settings Settings
+	logger   zerolog.Logger
 }
 
-func NewLogger(settings CommonSettings) Logger {
+func NewLogger(settings Settings) Logger {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
 
 	var zLogger zerolog.Logger
@@ -42,8 +42,8 @@ func NewLogger(settings CommonSettings) Logger {
 	}
 
 	return &logger{
-		appSettings: settings,
-		logger:      zLogger.With().Timestamp().Logger(),
+		settings: settings,
+		logger:   zLogger.With().Timestamp().Logger(),
 	}
 }
 
@@ -69,8 +69,8 @@ type logEvent struct {
 
 // add additional context to the event log
 func (l *logger) newEvent(ctx context.Context, event *zerolog.Event) LogEvent {
-	event.Str("hostname", l.appSettings.Hostname())
-	event.Str("appname", l.appSettings.Appname())
+	event.Str("hostname", l.settings.Hostname())
+	event.Str("appname", l.settings.Appname())
 
 	traceID := ctx.Value(ContextKeyTraceID)
 	if traceID != nil {

--- a/common/settings.go
+++ b/common/settings.go
@@ -9,20 +9,20 @@ import (
 
 // These are intended to be generic settings that every app is expected to implement.
 // packages in common can safely expect to have access to these settings in their constructors.
-type CommonSettings interface {
+type Settings interface {
 	Appname() string
 	Hostname() string
 	Env() string
 	IsDev() bool
 }
 
-type commonSettings struct {
+type settings struct {
 	env      string
 	appname  string
 	hostname string
 }
 
-func NewCommonSettings() CommonSettings {
+func NewSettings() Settings {
 	env := os.Getenv("ENV")
 	appname := os.Getenv("APP_NAME")
 
@@ -38,25 +38,25 @@ func NewCommonSettings() CommonSettings {
 		hostname = "localhost"
 	}
 
-	return &commonSettings{
+	return &settings{
 		env,
 		appname,
 		hostname,
 	}
 }
 
-func (s *commonSettings) Appname() string {
+func (s *settings) Appname() string {
 	return s.appname
 }
 
-func (s *commonSettings) Hostname() string {
+func (s *settings) Hostname() string {
 	return s.hostname
 }
 
-func (s *commonSettings) Env() string {
+func (s *settings) Env() string {
 	return s.env
 }
 
-func (s *commonSettings) IsDev() bool {
+func (s *settings) IsDev() bool {
 	return s.env == "dev"
 }

--- a/distributor/container.go
+++ b/distributor/container.go
@@ -18,7 +18,7 @@ func newContainer(ctx context.Context) *dig.Container {
 	}); err != nil {
 		panic(err)
 	}
-	if err := container.Provide(common.NewCommonSettings); err != nil {
+	if err := container.Provide(common.NewSettings); err != nil {
 		panic(err)
 	}
 	if err := container.Provide(common.NewLogger); err != nil {

--- a/distributor/controllers/distribute/distribute.go
+++ b/distributor/controllers/distribute/distribute.go
@@ -10,7 +10,7 @@ import (
 
 type Distributor interface {
 	Start(ctx context.Context)
-	Stop(ctx context.Context)
+	Shutdown(ctx context.Context)
 }
 
 type distributor struct {
@@ -38,8 +38,8 @@ func (d *distributor) Start(ctx context.Context) {
 	}
 }
 
-func (d *distributor) Stop(ctx context.Context) {
-	d.logger.Info(ctx).Msg("cleaning up distributor")
+func (d *distributor) Shutdown(ctx context.Context) {
+	d.logger.Info(ctx).Msg("shutting down distributor")
 }
 
 func (d *distributor) distribute(ctx context.Context) {

--- a/indexer/container.go
+++ b/indexer/container.go
@@ -20,7 +20,7 @@ func newContainer(ctx context.Context) *dig.Container {
 	}); err != nil {
 		panic(err)
 	}
-	if err := container.Provide(common.NewCommonSettings); err != nil {
+	if err := container.Provide(common.NewSettings); err != nil {
 		panic(err)
 	}
 	if err := container.Provide(common.NewLogger); err != nil {

--- a/indexer/controllers/index/index.go
+++ b/indexer/controllers/index/index.go
@@ -11,7 +11,7 @@ import (
 
 type Indexer interface {
 	Start(ctx context.Context)
-	Stop(ctx context.Context)
+	Shutdown(ctx context.Context)
 }
 
 type indexer struct {
@@ -47,6 +47,6 @@ func (i *indexer) Start(ctx context.Context) {
 }
 
 // Do any future shutdown resource cleanup here
-func (i *indexer) Stop(ctx context.Context) {
-	i.logger.Info(ctx).Msg("cleaning up indexer")
+func (i *indexer) Shutdown(ctx context.Context) {
+	i.logger.Info(ctx).Msg("shutting down indexer")
 }

--- a/indexer/gateways/ethereum/ethereum.go
+++ b/indexer/gateways/ethereum/ethereum.go
@@ -32,6 +32,10 @@ func NewEthereumGateway(logger com.Logger, settings settings.Settings) usecases.
 	}
 }
 
+func (g *ethereumGateway) Start(ctx context.Context) {}
+
+func (g *ethereumGateway) Shutdown(ctx context.Context) {}
+
 func (g *ethereumGateway) GetLatestBlockNumber(ctx context.Context) (*big.Int, error) {
 	header, err := g.ethClient.HeaderByNumber(ctx, nil)
 	if err == ethereum.NotFound {

--- a/indexer/usecases/gateways.go
+++ b/indexer/usecases/gateways.go
@@ -8,11 +8,15 @@ import (
 )
 
 type Database interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	GetLastIndexedBlock(context.Context) (*big.Int, error)
 	UpdateLastIndexedBlock(context.Context, *big.Int) error
 }
 
 type Blockchain interface {
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context)
 	GetLatestBlockNumber(ctx context.Context) (*big.Int, error)
 	GetTokenEvents(context.Context, *big.Int, *big.Int) ([]entities.TokenEvent, error)
 }


### PR DESCRIPTION
Moving a lot of resource opening/closing like db pools redis clients etc into explicit controller/gateway start/stop methods.
Using sync waitgroup to ensure controllers have observed context being marked as done and returned before proceeding with shutdown steps
Naming cleanup on common settings